### PR TITLE
Add vars.py

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -1,5 +1,5 @@
-<!-- title: About -->
-<h1>About</h1>
+<!-- title: {{ about_name }} -->
+<h1>{{ about_name }}</h1>
 <p>
 Quisque quam nisl, egestas nec convallis vitae, fringilla nec mauris.
 Sed et cursus lacus, a pharetra ex. Pellentesque rhoncus malesuada elit

--- a/content/contact.html
+++ b/content/contact.html
@@ -1,5 +1,5 @@
-<!-- title: Contact -->
-<h1>Contact</h1>
+<!-- title: {{ contact_name }} -->
+<h1>{{ contact_name }}</h1>
 <p>
 In hac habitasse platea dictumst. Suspendisse purus leo, laoreet ac
 scelerisque vitae, gravida vitae turpis. Etiam lacinia justo in pharetra

--- a/layout/page.html
+++ b/layout/page.html
@@ -15,10 +15,10 @@
         <a href="{{ base_path }}/">Home</a>
     </span>
     <span class="links">
-        <a href="{{ base_path }}/blog/">Blog</a>
-        <a href="{{ base_path }}/news/">News</a>
-        <a href="{{ base_path }}/contact/">Contact</a>
-        <a href="{{ base_path }}/about/">About</a>
+        <a href="{{ base_path }}/{{ blog_path }}/">{{ blog_name }}</a>
+        <a href="{{ base_path }}/{{ news_path }}/">{{ news_name }}</a>
+        <a href="{{ base_path }}/{{ contact_path }}/">{{ contact_name }}</a>
+        <a href="{{ base_path }}/{{ about_path }}/">{{ about_name }}</a>
     </span>
 </section>
 </nav>

--- a/makesite.py
+++ b/makesite.py
@@ -34,6 +34,23 @@ import glob
 import sys
 import json
 
+from vars import *
+
+
+def get_environment_name():
+    # Parse arguments
+    try:
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-e", "--env", type=str, help="Environment name",
+                            choices=['dev', 'prod', 'default'], default='default')
+        args = parser.parse_args()
+
+        return args.env
+    except ImportError as e:
+        print('`argparse` package missing, defaulting to `default` environment.')
+        return 'default'
+
 
 def fread(filename):
     """Read file and close the file."""
@@ -122,6 +139,9 @@ def make_pages(src, dst, layout, **params):
         content = read_content(src_path)
         items.append(content)
 
+        # Replace vars in content
+        content['content'] = render(content['content'], **params)
+
         params.update(content)
 
         dst_path = render(dst, **params)
@@ -149,18 +169,53 @@ def make_list(posts, dst, list_layout, item_layout, **params):
     fwrite(dst_path, output)
 
 
+def get_content_path(section, path):
+    """
+        Returns the directory used to store a section sources
+        Used to prevent the case where somebody would rename the path for the
+        blog section for not rename the `blog` directory in `content/`
+    """
+
+    if os.path.isdir(path):
+        return 'content/' + path
+    elif section == 'blog' and os.path.isdir('content/blog'):
+        return 'content/blog'
+    elif section == 'news' and os.path.isdir('content/news'):
+        return 'content/news'
+
+    return 'content/' + path
+
+
 def main():
-    # Create a new _site directory from scratch.
-    if os.path.isdir('_site'):
-        shutil.rmtree('_site')
-    shutil.copytree('static', '_site')
+    # Get environment name
+    env = get_environment_name()
+
+    # Set document root
+    documentroot = site_vars['envs'][env]['documentroot']
+
+    # Create a new document root directory from scratch.
+    if os.path.isdir(documentroot):
+        shutil.rmtree(documentroot)
+    shutil.copytree('static', documentroot)
 
     # Default parameters.
     params = {
-        'base_path': '',
-        'subtitle': 'Lorem Ipsum',
-        'author': 'Admin',
-        'site_url': 'http://localhost:8000',
+        'base_path': site_vars['envs'][env]['base_path'],
+        'subtitle': site_vars['subtitle'],
+        'author': site_vars['author'],
+        'site_url': site_vars['envs'][env]['site_url'],
+        # Blog vars
+        'blog_path': site_vars['blog']['path'],
+        'blog_name': site_vars['blog']['name'],
+        # News vars
+        'news_path': site_vars['news']['path'],
+        'news_name': site_vars['news']['name'],
+        # Contact vars
+        'contact_path': site_vars['contact']['path'],
+        'contact_name': site_vars['contact']['name'],
+        # About vars
+        'about_path': site_vars['about']['path'],
+        'about_name': site_vars['about']['name'],
     }
 
     # If params.json exists, load it.
@@ -180,29 +235,37 @@ def main():
     list_layout = render(page_layout, content=list_layout)
 
     # Create site pages.
-    make_pages('content/_index.html', '_site/index.html',
+    make_pages('content/_index.html', documentroot + '/index.html',
                page_layout, **params)
-    make_pages('content/[!_]*.html', '_site/{{ slug }}/index.html',
+    make_pages('content/[!_]*.html', documentroot + '/{{ slug }}/index.html',
                page_layout, **params)
 
     # Create blogs.
-    blog_posts = make_pages('content/blog/*.md',
-                            '_site/blog/{{ slug }}/index.html',
-                            post_layout, blog='blog', **params)
-    news_posts = make_pages('content/news/*.html',
-                            '_site/news/{{ slug }}/index.html',
-                            post_layout, blog='news', **params)
+    for section in site_vars['sections']:
+        log('Rendering section => {} ...', section)
 
-    # Create blog list pages.
-    make_list(blog_posts, '_site/blog/index.html',
-              list_layout, item_layout, blog='blog', title='Blog', **params)
-    make_list(news_posts, '_site/news/index.html',
-              list_layout, item_layout, blog='news', title='News', **params)
+        # Retrieve section dict
+        section_vars = site_vars.get(section, {})
 
-    make_list(blog_posts, '_site/blog/rss.xml',
-              feed_xml, item_xml, blog='blog', title='Blog', **params)
-    make_list(news_posts, '_site/news/rss.xml',
-              feed_xml, item_xml, blog='news', title='News', **params)
+        # Set section vats or defaults
+        s_path = section_vars.get('path', section)
+        s_ext = section_vars.get('files_extension', '.html')
+        s_name = section_vars.get('name', section.title())
+
+        # Make pages
+        section_pages = make_pages(get_content_path(section, s_path) + '/*' + s_ext,
+                                   documentroot + '/' + s_path +
+                                   '/{{ slug }}/index.html',
+                                   post_layout, blog=s_name, **params)
+
+        # Section index
+        make_list(section_pages, documentroot + '/' + s_path + '/index.html',
+                  list_layout, item_layout, blog=s_path, title=s_name, **params)
+
+        # Section RSS
+        make_list(section_pages, documentroot + '/' + s_path + '/rss.xml',
+                  feed_xml, item_xml, blog=s_path, title=s_name, **params)
+
 
 
 # Test parameter to be set temporarily by unit tests.

--- a/vars.py
+++ b/vars.py
@@ -1,0 +1,43 @@
+site_vars = {
+    'envs': {
+        'default': {
+            'base_path': '',
+            'site_url': 'http://localhost:8000',
+            'documentroot': '_site',
+        },
+        'dev': {
+            'base_path': '',
+            'site_url': 'http://localhost:8000',
+            'documentroot': '_site',
+        },
+        'prod':
+        {
+            'base_path': '',
+            'site_url': 'http://localhost:8000',
+            'documentroot': '_site',
+        },
+    },
+    'subtitle': 'Lorem Ipsum',
+    'author': 'Admin',
+    'sections': {
+        'blog', 'news'
+    },
+    'blog': {
+        'name': 'Blog',
+        'path': 'blog',
+        'files_extension': '.md',
+    },
+    'news': {
+        'name': 'News',
+        'path': 'news',
+        'files_extension': '.html',
+    },
+    'contact': {
+        'name': 'Contact',
+        'path': 'contact',
+    },
+    'about': {
+        'name': 'About',
+        'path': 'about',
+    }
+}


### PR DESCRIPTION
Create a `vars.py` file to store website vars in order to allow an easier website customization.

Also adds the following features:
 - Support for multiple optional environments (with different document root, base path and URL).
 - Add support for template variables (`{{ some_var }}`) in page content
 - Add support to add new sections (beyond `blog` and `news`)
 - Add support to switch file extension (`.md`, `.html`...) in each section