### PR TITLE
Additional parser

### DIFF
--- a/add_parser.py.sample
+++ b/add_parser.py.sample
@@ -1,0 +1,14 @@
+"""
+    Rename this file to `add_parser.py` to use this feature.
+
+    The additional parser allows you to manipulate the page HTML before it is rendered.
+"""
+
+
+def parse(text, filename):
+    """Add additional parsing logic"""
+
+    # Add a footnote
+    footnote = '<hr />my footnote'
+
+    return text + footnote

--- a/makesite.py
+++ b/makesite.py
@@ -57,14 +57,14 @@ def get_environment_name():
     return 'default'
 
 
-def import_additionnal_parser():
+def import_additional_parser():
     """Import an eventual parser created by the user"""
     # Parse arguments
     try:
         global add_parser
         import add_parser
     except ImportError as e:
-        print('No additionnal parser found.')
+        print('No additional parser found.')
         pass
 
 
@@ -213,8 +213,8 @@ def main():
     # Get environment name
     env = get_environment_name()
 
-    # Import optional additionnal parser
-    import_additionnal_parser()
+    # Import optional additional parser
+    import_additional_parser()
 
     # Set document root
     documentroot = site_vars['envs'][env]['documentroot']

--- a/makesite.py
+++ b/makesite.py
@@ -39,6 +39,7 @@ from vars import *
 
 
 def get_environment_name():
+    """Set environment name"""
     if __name__ == '__main__':
         # Parse arguments
         try:
@@ -54,6 +55,17 @@ def get_environment_name():
             pass
 
     return 'default'
+
+
+def import_additionnal_parser():
+    """Import an eventual parser created by the user"""
+    # Parse arguments
+    try:
+        global add_parser
+        import add_parser
+    except ImportError as e:
+        print('No additionnal parser found.')
+        pass
 
 
 def fread(filename):
@@ -119,6 +131,10 @@ def read_content(filename):
             text = CommonMark.commonmark(text)
         except ImportError as e:
             log('WARNING: Cannot render Markdown in {}: {}', filename, str(e))
+
+    # Optional additional parsing
+    if 'add_parser' in sys.modules:
+        text = add_parser.parse(text, filename)
 
     content.update({
         'content': text,
@@ -196,6 +212,9 @@ def get_content_path(section, path):
 def main():
     # Get environment name
     env = get_environment_name()
+
+    # Import optional additionnal parser
+    import_additionnal_parser()
 
     # Set document root
     documentroot = site_vars['envs'][env]['documentroot']


### PR DESCRIPTION
Allows the user to create a module `add_parser.py` to add additional parsing when rendering pages.

For example in markdown, if a user writes:
`# My title`

It will be converted to:
`<h1>My title</h1>`

The user could use the parser to add attributes to `<h1>` like:
`<h1 id="my_id">My title</h1>`
