### PR TITLE
Rename CommonMark to commonmark

### DIFF
--- a/makesite.py
+++ b/makesite.py
@@ -37,7 +37,7 @@ import datetime
 
 from jinja2 import Template, Environment, FileSystemLoader
 from bs4 import BeautifulSoup
-import CommonMark
+import commonmark
 
 from vars import *
 
@@ -119,7 +119,7 @@ def read_content(filename):
         variables, text = separate_content_and_variables(text)
 
         text = variables + "{% include 'md_header.html' %}" + \
-            CommonMark.commonmark(text) + "{% include 'md_footer.html' %}"
+            commonmark.commonmark(text) + "{% include 'md_footer.html' %}"
 
     # Optional additional parsing
     if 'add_parser' in sys.modules:


### PR DESCRIPTION
As per https://github.com/rtfd/CommonMark-py/blob/master/CHANGELOG.md:

```
[version] 0.8.1 (2018-09-06)

Removed CommonMark symlink. So, as of this version, you need to replace all instances of CommonMark with commonmark in your code.
```
